### PR TITLE
Fix resource distribution goal action acceptance for empty partitions

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
@@ -976,7 +976,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
     double prevDiff = (sourceBrokerUtilization / sourceBrokerCapacity) - (destinationBrokerUtilization / destinationBrokerCapacity);
     double nextDiff = prevDiff + (sourceUtilizationDelta / sourceBrokerCapacity) + (sourceUtilizationDelta / destinationBrokerCapacity);
 
-    return Math.abs(nextDiff) < Math.abs(prevDiff);
+    return Math.abs(nextDiff) <= Math.abs(prevDiff);
   }
 
   private boolean isSwapViolatingLimit(Replica sourceReplica, Replica destinationReplica) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoalTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.goals;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance;
+import com.linkedin.kafka.cruisecontrol.analyzer.ActionType;
+import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUnitTestUtils;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingAction;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.common.DeterministicCluster;
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResourceDistributionGoalTest {
+  private static final Map<Integer, Integer> RACK_BY_BROKER;
+  private static final Map<Resource, Double> BROKER_CAPACITY;
+
+  private static final String LARGE_TOPIC = "large-topic";
+  private static final String EMPTY_TOPIC = "empty-topic";
+
+  static {
+    RACK_BY_BROKER = Map.of(0, 0, 1, 1, 2, 2);
+  }
+  static {
+    BROKER_CAPACITY = Map.of(Resource.DISK, 100.0, Resource.CPU, 100.0, Resource.NW_IN, 100.0, Resource.NW_OUT, 100.0);
+  }
+
+  @Test
+  public void testActionAcceptanceForEmptyPartitions() throws Exception {
+    final var clusterModel = DeterministicCluster.getHomogeneousCluster(RACK_BY_BROKER, BROKER_CAPACITY, null);
+    // with only 4 partitions (8 with RF=2), the disk usage goal will be violated
+    // brokers 0 and 1 will be at 90% usage, broker 2 will be at 60% usage
+    roundRobinPartitionsOnBrokers(clusterModel, LARGE_TOPIC, 4, 30.0, List.of(0, 1, 2));
+
+    // add an empty topic with many partitions on only brokers 1 and 2
+    roundRobinPartitionsOnBrokers(clusterModel, EMPTY_TOPIC, 1000, 0.0, List.of(1, 2));
+
+    // We use DiskUsageDistributionGoal here, but any ResourceDistributionGoal would work
+    final var diskUsageDistributionGoal = (DiskUsageDistributionGoal) AnalyzerUnitTestUtils.goal(DiskUsageDistributionGoal.class);
+    final var optimizationOptions = new OptimizationOptions(Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+    diskUsageDistributionGoal.initGoalState(clusterModel, optimizationOptions);
+
+    // the disk usage goal is violated, but should still be acceptable to try to move the partitions of the
+    // empty topic from broker 2 to broker 0 to balance the replica count
+    final var toMovePartition = new TopicPartition(EMPTY_TOPIC, 0);
+    final var balancingAction = new BalancingAction(toMovePartition, 2, 0, ActionType.INTER_BROKER_REPLICA_MOVEMENT);
+
+    final var result = diskUsageDistributionGoal.actionAcceptance(balancingAction, clusterModel);
+    assertEquals(ActionAcceptance.ACCEPT, result);
+  }
+
+  private void roundRobinPartitionsOnBrokers(
+      ClusterModel clusterModel,
+      String topicName,
+      int numPartitions,
+      double partitionLoad,
+      List<Integer> targetBrokers
+  ) {
+    // add replicas of rf=2 topic in a round-robin fashion on the targetBrokers
+    for (int i = 0; i < numPartitions; i++) {
+      final var leaderBroker = targetBrokers.get(i % targetBrokers.size());
+      final var followerBroker = targetBrokers.get((i + 1) % targetBrokers.size());
+      final var tp = new TopicPartition(topicName, i);
+      clusterModel.createReplica(rackId(leaderBroker), leaderBroker, tp, 0, true);
+      clusterModel.createReplica(rackId(followerBroker), followerBroker, tp, 1, false);
+
+      final var load = DeterministicCluster.createLoad(partitionLoad, partitionLoad, partitionLoad, partitionLoad);
+      final var windows = Collections.singletonList(1L);
+      clusterModel.setReplicaLoad(rackId(leaderBroker), leaderBroker, tp, load, windows);
+      clusterModel.setReplicaLoad(rackId(followerBroker), followerBroker, tp, load, windows);
+    }
+  }
+
+  private String rackId(int brokerId) {
+    return RACK_BY_BROKER.get(brokerId).toString();
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
@@ -1878,7 +1878,7 @@ public final class DeterministicCluster {
     return cluster;
   }
 
-  private static AggregatedMetricValues createLoad(double cpu, double networkIn, double networkOut, double disk) {
+  public static AggregatedMetricValues createLoad(double cpu, double networkIn, double networkOut, double disk) {
     return getAggregatedMetricValues(cpu, networkIn, networkOut, disk);
   }
 


### PR DESCRIPTION
It's pretty common for there to at least one `ResourceDistributionGoals` violated (not within acceptable thresholds), reasons could be:
* Clusters with multiple broker sets (a.k.a. pools), resource distribution may not be even across the cluster by design
* Clusters which are difficult to balance (e.g. not enough partitions) may well not be able to satisfy all resource usage (disk, network in, network out, cpu) distribution goals simultaneously

When CC is attempting to optimise a later goal it will check it's not going to make previous goals worse by calling [actionAcceptance](https://github.com/DataDog/cruise-control/blob/14f48dcb7260bc8e265172ae2cbc3fa57f742769/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java#L102). In the cases where the resource distribution goal is violated, this ultimately gets to `isGettingMoreBalanced`. However there is a bug (fixed in this PR) in `isGettingMoreBalanced` which will reject all movements of replicas that take zero resource usage.

If we reject all movements of empty replicas, then this can lead to very imbalanced replica usage on a cluster. This is particularly a problem if the empty replicas belong to a new topic that has not yet received traffic, because when traffic ramps up some brokers might get overwhelmed.

Also added a unit test that fails on master but passes on this branch to show the issue.