### PR TITLE
Do not reuse broker stats cache if time window is different

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/LoadRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/LoadRunnable.java
@@ -60,7 +60,7 @@ public class LoadRunnable extends OperationRunnable {
 
   @Override
   protected BrokerStats getResult() throws Exception {
-    if (!_populateDiskInfo) {
+    if (!_populateDiskInfo && _start == DEFAULT_START_TIME_FOR_CLUSTER_MODEL) {
       // Check whether the cached broker stats is still valid.
       BrokerStats cachedBrokerStats = _kafkaCruiseControl.cachedBrokerLoadStats(_allowCapacityEstimation);
       if (cachedBrokerStats != null) {


### PR DESCRIPTION
Fixes: https://github.com/linkedin/cruise-control/issues/2154

Cruise Control wrongly reuses cached BrokerStats even if the query is for a different time window. This resulted in load requests ignoring the explicit time window passed as argument by the cluster rightsizer.

With the new change, CruiseControl would only return cached BrokerStats if the time window matches the default window. 

![Network In  Current usage per broker](https://github.com/user-attachments/assets/51a91781-679d-4003-a043-2a12b3136ab4)
Traffic ramping up: unpatched version of cruise control
Traffic decreasing: patched version of cruise control


See [notebook](https://ddstaging.datadoghq.com/notebook/10367674/-streams-cc-bug) for more details.
