### PR TITLE
Reduce number of retries to remove throttle

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsUtils.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsUtils.java
@@ -29,6 +29,7 @@ public final class CruiseControlMetricsUtils {
   public static final long CLIENT_REQUEST_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
 
   private static final long DEFAULT_RETRY_BACKOFF_SCALE_MS = TimeUnit.SECONDS.toMillis(5);
+  private static final long DEFAULT_RETRY_BACKOFF_MAX_MS = Long.MAX_VALUE;
   private static final int DEFAULT_RETRY_BACKOFF_BASE = 2;
 
   public static final String ENV_CONFIG_PROVIDER_NAME = "env";
@@ -163,10 +164,11 @@ public final class CruiseControlMetricsUtils {
    * @param scaleMs the scale for computing the delay
    * @param base the base for computing the delay
    * @param maxAttempts the max number of attempts on calling the function
+   * @param maxDelayMs the max delay between attempts
    * @return {@code false} if the function requires a retry, but it cannot be retried, because the max attempts have been exceeded.
    * {@code true} if the function stopped requiring a retry before exceeding the max attempts.
    */
-  public static boolean retry(Supplier<Boolean> function, long scaleMs, int base, int maxAttempts) {
+  public static boolean retry(Supplier<Boolean> function, long scaleMs, int base, int maxAttempts, long maxDelayMs) {
     if (maxAttempts > 0) {
       int attempts = 0;
       long timeToSleep = scaleMs;
@@ -178,7 +180,7 @@ public final class CruiseControlMetricsUtils {
             if (++attempts == maxAttempts) {
               return false;
             }
-            timeToSleep *= base;
+            timeToSleep = Math.min(timeToSleep * base, maxDelayMs);
             Thread.sleep(timeToSleep);
           } catch (InterruptedException ignored) {
 
@@ -193,14 +195,28 @@ public final class CruiseControlMetricsUtils {
 
   /**
    * Retries the {@code Supplier<Boolean>} function while it returns {@code true} and for the specified max number of attempts.
-   * It uses {@code DEFAULT_RETRY_BACKOFF_SCALE_MS} and {@code DEFAULT_RETRY_BACKOFF_BASE} for scale and base to compute the delay.
+   * It uses {@code DEFAULT_RETRY_BACKOFF_SCALE_MS} and {@code DEFAULT_RETRY_BACKOFF_BASE} for scale and base to compute the delay,
+   * as well as {@code DEFAULT_RETRY_BACKOFF_MAX_MS} for the upper bound of delay between attempts.
    * @param function the code to call and retry if needed
    * @param maxAttempts the max number of attempts on calling the function
    * @return {@code false} if the function requires a retry, but it cannot be retried, because the max attempts have been exceeded.
    * {@code true} if the function stopped requiring a retry before exceeding the max attempts.
    */
   public static boolean retry(Supplier<Boolean> function, int maxAttempts) {
-    return retry(function, DEFAULT_RETRY_BACKOFF_SCALE_MS, DEFAULT_RETRY_BACKOFF_BASE, maxAttempts);
+    return retry(function, DEFAULT_RETRY_BACKOFF_SCALE_MS, DEFAULT_RETRY_BACKOFF_BASE, maxAttempts, DEFAULT_RETRY_BACKOFF_MAX_MS);
+  }
+
+  /**
+   * Retries the {@code Supplier<Boolean>} function while it returns {@code true} and for the specified max number of attempts.
+   * It uses {@code DEFAULT_RETRY_BACKOFF_SCALE_MS} and {@code DEFAULT_RETRY_BACKOFF_BASE} for scale and base to compute the delay.
+   * @param function the code to call and retry if needed
+   * @param maxAttempts the max number of attempts on calling the function
+   * @param maxDelayMs the max delay between attempts.
+   * @return {@code false} if the function requires a retry, but it cannot be retried, because the max attempts have been exceeded.
+   * {@code true} if the function stopped requiring a retry before exceeding the max attempts.
+   */
+  public static boolean retry(Supplier<Boolean> function, int maxAttempts, long maxDelayMs) {
+    return retry(function, DEFAULT_RETRY_BACKOFF_SCALE_MS, DEFAULT_RETRY_BACKOFF_BASE, maxAttempts, maxDelayMs);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -48,33 +48,37 @@ class ReplicationThrottleHelper {
   static final String LEADER_THROTTLED_REPLICAS = getLogConfig(LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG);
   static final String FOLLOWER_THROTTLED_REPLICAS = getLogConfig(LogConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG);
   public static final long CLIENT_REQUEST_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
-  static final int RETRIES = 30;
+  static final int RETRIES = 3;
+  static final long MAX_DELAY_MS = TimeUnit.SECONDS.toMillis(10);
 
   private final AdminClient _adminClient;
   private final Long _throttleRate;
   private final int _retries;
+  private long _maxDelayMs;
   private final Set<Integer> _deadBrokers;
 
   ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate) {
-    this(adminClient, throttleRate, RETRIES);
+    this(adminClient, throttleRate, RETRIES, MAX_DELAY_MS);
   }
 
   ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, Set<Integer> deadBrokers) {
-    this(adminClient, throttleRate, RETRIES, deadBrokers);
+    this(adminClient, throttleRate, RETRIES, MAX_DELAY_MS, deadBrokers);
   }
 
   // for testing
-  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, int retries) {
+  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, int retries, long maxDelayMs) {
     this._adminClient = adminClient;
     this._throttleRate = throttleRate;
     this._retries = retries;
+    this._maxDelayMs = maxDelayMs;
     this._deadBrokers = new HashSet<Integer>();
   }
 
-  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, int retries, Set<Integer> deadBrokers) {
+  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, int retries, long maxDelayMs, Set<Integer> deadBrokers) {
     this._adminClient = adminClient;
     this._throttleRate = throttleRate;
     this._retries = retries;
+    this._maxDelayMs = maxDelayMs;
     this._deadBrokers = deadBrokers;
   }
 
@@ -374,7 +378,7 @@ class ReplicationThrottleHelper {
       } catch (ExecutionException | InterruptedException | TimeoutException e) {
         return false;
       }
-    }, _retries);
+    }, _retries, _maxDelayMs);
     if (!retryResponse) {
       throw new IllegalStateException("The following configs " + ops + " were not applied to " + cf + " within the time limit");
     }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -479,12 +479,13 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   public void testWaitForConfigs() throws Exception {
     AdminClient mockAdminClient = EasyMock.strictMock(AdminClient.class);
     int retries = 3;
+    int maxDelayMs = 1000;
     // Case 1: queue more responses than RETRIES and expect checkConfigs to throw
     for (int i = 0; i < retries + 1; i++) {
       expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, true);
     }
     EasyMock.replay(mockAdminClient);
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, 100L, retries);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, 100L, maxDelayMs, retries);
     ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, TOPIC0);
     assertThrows(IllegalStateException.class, () -> throttleHelper.waitForConfigs(cf, Collections.singletonList(
             new AlterConfigOp(new ConfigEntry("k", "v"), AlterConfigOp.OpType.SET)


### PR DESCRIPTION
Setting the retries to 30 amounts to retrying forever, or at least for longer than the Kafka cluster will exist (~170 years). We'd rather throw and abort the reassignment process, so that we can kick it off from scratch again than have Cruise Control turn non-operational without manual action.