### PR TITLE
[cruise-control] default the cc-cli to using tls

### DIFF
--- a/cruise-control-client/cruisecontrolclient/client/ExecutionContext.py
+++ b/cruise-control-client/cruisecontrolclient/client/ExecutionContext.py
@@ -20,7 +20,7 @@ class ExecutionContext:
         Endpoint.LoadEndpoint,
         Endpoint.PartitionLoadEndpoint,
         Endpoint.PauseSamplingEndpoint,
-        Endpoint.Permissions,
+        Endpoint.PermissionsEndpoint,
         Endpoint.ProposalsEndpoint,
         Endpoint.RebalanceEndpoint,
         Endpoint.RemoveBrokerEndpoint,

--- a/cruise-control-client/cruisecontrolclient/client/Query.py
+++ b/cruise-control-client/cruisecontrolclient/client/Query.py
@@ -24,7 +24,7 @@ def generate_url_from_cc_socket_address(cc_socket_address: str, endpoint: Abstra
                   "It may be removed entirely in future versions.",
                   DeprecationWarning,
                   stacklevel=2)
-    url = f"http://{cc_socket_address}/kafkacruisecontrol/{endpoint.compose_endpoint()}"
+    url = f"https://{cc_socket_address}/kafkacruisecontrol/{endpoint.compose_endpoint()}"
     return url
 
 
@@ -40,5 +40,5 @@ def generate_base_url_from_cc_socket_address(cc_socket_address: str, endpoint: A
     :return: URL, the correct URL to perform the Endpoint's operation
              on the given cruise-control host, _excluding parameters_.
     """
-    url = f"http://{cc_socket_address}/kafkacruisecontrol/{endpoint.name}"
+    url = f"https://{cc_socket_address}/kafkacruisecontrol/{endpoint.name}"
     return url

--- a/cruise-control-client/cruisecontrolclient/client/Responder.py
+++ b/cruise-control-client/cruisecontrolclient/client/Responder.py
@@ -19,6 +19,9 @@ from urllib.parse import urlencode
 # To inform humans about possibly too-old versions of cruise-control
 import warnings
 
+# To parse command-line arguments
+import argparse
+
 # To currectly determine version
 import re
 
@@ -29,6 +32,11 @@ class CruiseControlResponder(requests.Session):
     in order to provide the cruise-control-client with some basic
     sanity checking and session-management functionality.
     """
+
+    def __init__(self, args: argparse.Namespace):
+        super().__init__()
+        # Configure SSL verification to use system CA store
+        self.verify = args.ssl_cert if not args.insecure else False
 
     def retrieve_response(self, method, url, **kwargs) -> requests.Response:
         """

--- a/cruise-control-client/cruisecontrolclient/client/cccli.py
+++ b/cruise-control-client/cruisecontrolclient/client/cccli.py
@@ -28,6 +28,9 @@ def get_endpoint(args: argparse.Namespace,
     # removing properties, not mutating the objects which those properties reference.
     arg_dict = vars(args).copy()
 
+    if args.endpoint_subparser not in execution_context.dest_to_Endpoint:
+        raise ValueError(f"Invalid endpoint: {args.endpoint_subparser}")
+
     # If we have a broker list, we need to make it into a comma-separated list
     # and pass it to the Endpoint at instantiation.
     if 'brokers' in arg_dict:
@@ -176,7 +179,11 @@ def build_argument_parser(execution_context: ExecutionContext) -> argparse.Argum
     parser = argparse.ArgumentParser()
     parser.add_argument('-a', '--socket-address', help="The hostname[:port] of the cruise-control to interact with",
                         required=True)
+    parser.add_argument("-k", "--insecure", action='store_true', help="Disable SSL verification")
+    parser.add_argument("--ssl-cert", help="Path to SSL certificate file", default="/etc/ssl/certs")
     execution_context.non_parameter_flags.add('socket_address')
+    execution_context.non_parameter_flags.add('insecure')
+    execution_context.non_parameter_flags.add('ssl_cert')
 
     # Define subparser for the different cruise-control endpoints
     #
@@ -221,7 +228,7 @@ def main():
     cc_socket_address = args.socket_address
 
     # Retrieve the response and display it
-    json_responder = CruiseControlResponder()
+    json_responder = CruiseControlResponder(args)
     response = json_responder.retrieve_response_from_Endpoint(cc_socket_address, endpoint)
     print(response.text)
 


### PR DESCRIPTION
## Summary
Default the cruisecontrol cli to using TLS with overrides to disable cert validation. Also added a small logging change to throw a more helpful log when no command is passed.

Will need to follow up with changes to publish a wheel to ddbuild.