### PR TITLE
[cruise-control] add metrics for goal level actions

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
@@ -156,7 +156,7 @@ public final class AnalyzerUtils {
     }
     return hasDiff;
   }
-
+  
   /**
    * Check whether the given proposal is acceptable for all of the given optimized goals.
    *
@@ -170,7 +170,7 @@ public final class AnalyzerUtils {
                                                                        BalancingAction proposal,
                                                                        ClusterModel clusterModel) {
     for (Goal optimizedGoal : optimizedGoals) {
-      ActionAcceptance actionAcceptance = optimizedGoal.actionAcceptance(proposal, clusterModel);
+      ActionAcceptance actionAcceptance = optimizedGoal.actionAcceptanceInstrumented(proposal, clusterModel);
       if (actionAcceptance != ACCEPT) {
         return actionAcceptance;
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -9,6 +9,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.linkedin.kafka.cruisecontrol.common.Utils;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.AbstractGoal;
 import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
@@ -90,6 +91,7 @@ public class GoalOptimizer implements Runnable {
   private final double _strictnessWeight;
   private final OptimizationOptionsGenerator _optimizationOptionsGenerator;
   private volatile boolean _hasUnfixableProposalOptimization;
+  private final MetricRegistry _metricRegistry;
 
   /**
    * Constructor for Goal Optimizer takes the goals as input. The order of the list determines the priority of goals
@@ -140,6 +142,7 @@ public class GoalOptimizer implements Runnable {
     _optimizationOptionsGenerator = config.getConfiguredInstance(AnalyzerConfig.OPTIMIZATION_OPTIONS_GENERATOR_CLASS_CONFIG,
                                                                  OptimizationOptionsGenerator.class,
                                                                  overrideConfigs);
+    _metricRegistry = dropwizardMetricRegistry;
   }
 
   /**
@@ -464,6 +467,9 @@ public class GoalOptimizer implements Runnable {
       long startTimeMs = _time.milliseconds();
       boolean succeeded;
       try {
+        if (goal instanceof AbstractGoal) {
+          ((AbstractGoal) goal).registerMetrics(_metricRegistry);
+        }
         succeeded = goal.optimize(clusterModel, optimizedGoals, optimizationOptions);
       } catch (OptimizationFailureException e) {
         setHasUnfixableProposalOptimization(true, goalsByPriority);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -21,6 +21,8 @@ import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.model.Disk;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -50,6 +52,22 @@ public abstract class AbstractGoal implements Goal {
   protected int _numWindows;
   protected double _minMonitoredPartitionPercentage;
   protected ProvisionResponse _provisionResponse;
+  
+  // JMX Metrics
+  private Counter _movementsProposed;
+  private Counter _movementsExecuted;
+  private Counter _movementsRejected;
+  private Counter _swapsProposed;
+  private Counter _swapsExecuted;
+  private Counter _swapsRejected;
+  private Counter _intraBrokerMovementsProposed;
+  private Counter _intraBrokerMovementsExecuted;
+  private Counter _intraBrokerMovementsRejected;
+  private Counter _intraBrokerSwapsProposed;
+  private Counter _intraBrokerSwapsExecuted;
+  private Counter _intraBrokerSwapsRejected;
+  private Counter _goalsRejected;
+  private Counter _selfRejections;
 
   /**
    * Constructor of Abstract Goal class sets the
@@ -71,6 +89,28 @@ public abstract class AbstractGoal implements Goal {
     _balancingConstraint = new BalancingConstraint(parsedConfig);
     _numWindows = parsedConfig.getInt(MonitorConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG);
     _minMonitoredPartitionPercentage = parsedConfig.getDouble(MonitorConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
+  }
+  
+  /**
+   * Set the metric registry and initialize JMX metrics for this goal.
+   * @param metricRegistry the metricRegistry to set.
+   */
+  public void registerMetrics(MetricRegistry metricRegistry) {
+    String goalName = name();
+    _movementsProposed = metricRegistry.counter(MetricRegistry.name(goalName, "movements-proposed"));
+    _movementsExecuted = metricRegistry.counter(MetricRegistry.name(goalName, "movements-executed"));
+    _movementsRejected = metricRegistry.counter(MetricRegistry.name(goalName, "movements-rejected"));
+    _swapsProposed = metricRegistry.counter(MetricRegistry.name(goalName, "swaps-proposed"));
+    _swapsExecuted = metricRegistry.counter(MetricRegistry.name(goalName, "swaps-executed"));
+    _swapsRejected = metricRegistry.counter(MetricRegistry.name(goalName, "swaps-rejected"));
+    _intraBrokerMovementsProposed = metricRegistry.counter(MetricRegistry.name(goalName, "intra-broker-movements-proposed"));
+    _intraBrokerMovementsExecuted = metricRegistry.counter(MetricRegistry.name(goalName, "intra-broker-movements-executed"));
+    _intraBrokerMovementsRejected = metricRegistry.counter(MetricRegistry.name(goalName, "intra-broker-movements-rejected"));
+    _intraBrokerSwapsProposed = metricRegistry.counter(MetricRegistry.name(goalName, "intra-broker-swaps-proposed"));
+    _intraBrokerSwapsExecuted = metricRegistry.counter(MetricRegistry.name(goalName, "intra-broker-swaps-executed"));
+    _intraBrokerSwapsRejected = metricRegistry.counter(MetricRegistry.name(goalName, "intra-broker-swaps-rejected"));
+    _selfRejections = metricRegistry.counter(MetricRegistry.name(goalName, "self-rejections"));
+    _goalsRejected = metricRegistry.counter(MetricRegistry.name(goalName, "proposals-rejected-by-goal"));
   }
 
   private static boolean hasExcludedBrokersForReplicaMoveWithReplicas(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
@@ -254,21 +294,43 @@ public abstract class AbstractGoal implements Goal {
 
       if (!selfSatisfied(clusterModel, proposal)) {
         LOG.trace("Unable to self-satisfy proposal {}.", proposal);
+        if (_selfRejections != null) {
+          _selfRejections.inc();
+        }
         continue;
       }
 
+      if (_movementsProposed != null) {
+        _movementsProposed.inc();
+      }
       ActionAcceptance acceptance = AnalyzerUtils.isProposalAcceptableForOptimizedGoals(optimizedGoals, proposal, clusterModel);
       LOG.trace("Trying to apply legit and self-satisfied action {}, actionAcceptance = {}", proposal, acceptance);
       if (acceptance == ACCEPT) {
+        if (_movementsExecuted != null) {
+          _movementsExecuted.inc();
+        }
         if (action == ActionType.LEADERSHIP_MOVEMENT) {
           clusterModel.relocateLeadership(replica.topicPartition(), replica.broker().id(), broker.id());
         } else if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT) {
           clusterModel.relocateReplica(replica.topicPartition(), replica.broker().id(), broker.id());
         }
         return broker;
+      } else {
+        if (_movementsRejected != null) {
+          _movementsRejected.inc();
+        }
       }
     }
     return null;
+  }
+
+  @Override
+  public ActionAcceptance actionAcceptanceInstrumented(BalancingAction action, ClusterModel clusterModel) {
+    ActionAcceptance actionAcceptance = actionAcceptance(action, clusterModel);
+    if (actionAcceptance != ACCEPT && _goalsRejected != null) {
+      _goalsRejected.inc();
+    }
+    return actionAcceptance;
   }
 
   /**
@@ -319,19 +381,36 @@ public abstract class AbstractGoal implements Goal {
       if (!selfSatisfied(clusterModel, swapProposal)) {
         // Unable to satisfy proposal for this eligible replica and the remaining eligible replicas in the list.
         LOG.trace("Unable to self-satisfy swap proposal {}.", swapProposal);
+        if (_selfRejections != null) {
+          _selfRejections.inc();
+        }
         return null;
+      }
+      
+      if (_swapsProposed != null) {
+        _swapsProposed.inc();
       }
       ActionAcceptance acceptance = AnalyzerUtils.isProposalAcceptableForOptimizedGoals(optimizedGoals, swapProposal, clusterModel);
       LOG.trace("Trying to apply legit and self-satisfied swap {}, actionAcceptance = {}.", swapProposal, acceptance);
 
       if (acceptance == ACCEPT) {
+        if (_swapsExecuted != null) {
+          _swapsExecuted.inc();
+        }
         Broker sourceBroker = sourceReplica.broker();
         clusterModel.relocateReplica(sourceReplica.topicPartition(), sourceBroker.id(), destinationBroker.id());
         clusterModel.relocateReplica(destinationReplica.topicPartition(), destinationBroker.id(), sourceBroker.id());
         return destinationReplica;
       } else if (acceptance == BROKER_REJECT) {
+        if (_swapsRejected != null) {
+          _swapsRejected.inc();
+        }
         // Unable to swap the given source replica with any replicas in the destination broker.
         return null;
+      } else {
+        if (_swapsRejected != null) {
+          _swapsRejected.inc();
+        }
       }
     }
     return null;
@@ -364,14 +443,27 @@ public abstract class AbstractGoal implements Goal {
 
       if (!selfSatisfied(clusterModel, proposal)) {
         LOG.trace("Unable to self-satisfy proposal {}.", proposal);
+        if (_selfRejections != null) {
+          _selfRejections.inc();
+        }
         continue;
       }
 
+      if (_intraBrokerMovementsProposed != null) {
+        _intraBrokerMovementsProposed.inc();
+      }
       ActionAcceptance acceptance = AnalyzerUtils.isProposalAcceptableForOptimizedGoals(optimizedGoals, proposal, clusterModel);
       LOG.trace("Trying to apply legit and self-satisfied action {}, actionAcceptance = {}", proposal, acceptance);
       if (acceptance == ACCEPT) {
+        if (_intraBrokerMovementsExecuted != null) {
+          _intraBrokerMovementsExecuted.inc();
+        }
         clusterModel.relocateReplica(replica.topicPartition(), replica.broker().id(), disk.logDir());
         return disk;
+      } else {
+        if (_intraBrokerMovementsRejected != null) {
+          _intraBrokerMovementsRejected.inc();
+        }
       }
     }
     return null;
@@ -415,15 +507,28 @@ public abstract class AbstractGoal implements Goal {
       if (!selfSatisfied(clusterModel, swapProposal)) {
         // Unable to satisfy proposal for this eligible replica and the remaining eligible replicas in the list.
         LOG.trace("Unable to self-satisfy swap proposal {}.", swapProposal);
+        if (_selfRejections != null) {
+          _selfRejections.inc();
+        }
         return null;
       }
 
+      if (_intraBrokerSwapsProposed != null) {
+        _intraBrokerSwapsProposed.inc();
+      }
       ActionAcceptance acceptance = AnalyzerUtils.isProposalAcceptableForOptimizedGoals(optimizedGoals, swapProposal, clusterModel);
       LOG.trace("Trying to apply legit and self-satisfied swap {}, actionAcceptance = {}.", swapProposal, acceptance);
       if (acceptance == ACCEPT) {
+        if (_intraBrokerSwapsExecuted != null) {
+          _intraBrokerSwapsExecuted.inc();
+        }
         clusterModel.relocateReplica(sourceReplica.topicPartition(), sourceReplica.broker().id(), destinationReplica.disk().logDir());
         clusterModel.relocateReplica(destinationReplica.topicPartition(), destinationReplica.broker().id(), sourceReplica.disk().logDir());
         return destinationReplica;
+      } else {
+        if (_intraBrokerSwapsRejected != null) {
+          _intraBrokerSwapsRejected.inc();
+        }
       }
     }
     return null;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/Goal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/Goal.java
@@ -81,6 +81,20 @@ public interface Goal extends CruiseControlConfigurable {
   ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel);
 
   /**
+   * Check whether the given action is acceptable by this goal in the given state of the cluster. An action is
+   * (1) accepted by a goal if it satisfies requirements of the goal, or (2) rejected by a goal if it violates its
+   * requirements. The return value indicates whether the action is accepted or why it is rejected.
+   * It is assumed that the given action does not involve replicas regarding excluded topics.
+   *
+   * @param action Action to be checked for acceptance.
+   * @param clusterModel State of the cluster before application of the action.
+   * @return The action acceptance indicating whether an action is accepted, or why it is rejected.
+   */
+  default ActionAcceptance actionAcceptanceInstrumented(BalancingAction action, ClusterModel clusterModel) {
+    return actionAcceptance(action, clusterModel);
+  }
+
+  /**
    * Get an instance of {@link ClusterModelStatsComparator} for this goal.
    *
    * The {@link ClusterModelStatsComparator#compare(ClusterModelStats, ClusterModelStats)} method should give a

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -556,13 +556,13 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
     KafkaFuture<Map<ConfigResource, Config>> mockFuture = EasyMock.mock(KafkaFuture.class);
     if (topicExists) {
-      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(topicConfigs);
+      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(topicConfigs).anyTimes();
     } else {
       EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject()))
-              .andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
+              .andThrow(new ExecutionException(new UnknownTopicOrPartitionException())).anyTimes();
     }
-    EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture);
-    EasyMock.expect(adminClient.describeConfigs(Collections.singletonList(cf))).andReturn(mockDescribeConfigsResult);
+    EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture).anyTimes();
+    EasyMock.expect(adminClient.describeConfigs(Collections.singletonList(cf))).andReturn(mockDescribeConfigsResult).anyTimes();
     EasyMock.replay(mockDescribeConfigsResult, mockFuture);
   }
 


### PR DESCRIPTION
## Summary
Adding metrics on abstract goal that emit info about how many movements a goal is proposing, how many execute, how many are rejected, and how many the goal is responsible for rejecting.

The registerMetrics section is pretty janky because I couldn't figure out how to inject metricRegistry into goal creation but it seems to work okay. I was trying to keep the # of files changed limited to avoid issues with upstream merges
