### PR TITLE
Revert "quote startup options"

### DIFF
--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -188,5 +188,5 @@ fi
 if [ "x$DAEMON_MODE" = "xtrue" ]; then
   nohup $JAVA $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp $CLASSPATH $KAFKA_OPTS com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
 else
-  exec $JAVA "$KAFKA_HEAP_OPTS" "$KAFKA_JVM_PERFORMANCE_OPTS" "$KAFKA_GC_LOG_OPTS" "$KAFKA_JMX_OPTS" "$KAFKA_LOG4J_OPTS" -cp "$CLASSPATH" "$KAFKA_OPTS" com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain "$@"
+  exec $JAVA $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp $CLASSPATH $KAFKA_OPTS com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain "$@"
 fi


### PR DESCRIPTION
This reverts commit 612d0b02a835309602731822642bbe8aba245063.

The reverted commit led to

```
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
Unrecognized VM option 'UseContainerSupport -XX:InitialRAMPercentage=25 -XX:MaxRAMPercentage=65'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```