### PR TITLE
Georgew5656/streams 4509 don't try to remove broker throttles if they are default dynamic throttles.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -10,6 +10,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.ConfigEntry.ConfigSource;
 import org.apache.kafka.common.config.ConfigResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -342,16 +343,18 @@ class ReplicationThrottleHelper {
     ConfigEntry currFollowerThrottle = brokerConfigs.get(FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG);
     List<AlterConfigOp> ops = new ArrayList<>();
     if (currLeaderThrottle != null) {
-      if (currLeaderThrottle.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)) {
-        LOG.debug("Skipping removal for static leader throttle rate: {}", currFollowerThrottle);
+      if (currLeaderThrottle.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)
+          || currLeaderThrottle.source().equals(ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)) {
+        LOG.debug("Skipping removal for global leader throttle rate: {}", currFollowerThrottle);
       } else {
         LOG.debug("Removing leader throttle rate: {} on broker {}", currLeaderThrottle, brokerId);
         ops.add(new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_RATE_CONFIG, null), AlterConfigOp.OpType.DELETE));
       }
     }
     if (currFollowerThrottle != null) {
-      if (currFollowerThrottle.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)) {
-        LOG.debug("Skipping removal for static follower throttle rate: {}", currFollowerThrottle);
+      if (currFollowerThrottle.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)
+          || currFollowerThrottle.source().equals(ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)) {
+        LOG.debug("Skipping removal for global follower throttle rate: {}", currFollowerThrottle);
       } else {
         LOG.debug("Removing follower throttle rate: {} on broker {}", currFollowerThrottle, brokerId);
         ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, null), AlterConfigOp.OpType.DELETE));


### PR DESCRIPTION
## Summary
Currently cruise control won't try to unset broker throttles after a rebalance has finished if it detects the throttles are static configs. This makes sense because unsetting these throttles won't do anything.

Trying to unset default dynamic throttles won't do anything either because cruise control uses the per broker ConfigResource to set/unset throttles rather than broker: *, but cruise control still tries to set throttles in this situation. This means that if a default dynamic throttle is set, cruise control needlessly spends extra time trying to unset throttles even those these operations are no-ops.

This change updates the cruise control logic to also ignore default dynamic throttles.
