### PR TITLE
[cruise-control] ignore default dynamic replication throttles when setting throttles

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -389,8 +389,9 @@ class ReplicationThrottleHelper {
         if (entry.getValue() != null) {
           return false;
         }
-      } else if (configEntry.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG) && entry.getValue() == null) {
-        LOG.debug("Found static broker config: {}, skipping comparison", configEntry);
+      } else if ((configEntry.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)
+          || configEntry.source().equals(ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)) && entry.getValue() == null) {
+        LOG.debug("Found global broker config: {}, skipping comparison", configEntry);
       } else if (!Objects.equals(entry.getValue(), configEntry.value())) {
         return false;
       }


### PR DESCRIPTION
This change https://github.com/DataDog/cruise-control/pull/23 tells cruise control to ignore replication throttles if they are set through a default dynamic config but didn't update this logic in configsEqual, this is a problem if a custom broker level throttle is set on top of default cluster wide config. Cruise control will try to remove the custom broker throttle and expects the replication throttle to be null (but this will never happen because of the default cluster wide throttle).