### PR TITLE
Fix CC runtime vuln deps (commons-io, lz4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,17 @@ subprojects {
       implementation("net.minidev:json-smart:2.5.0") {
         because("CVE-2023-1370 - transitive from json-path")
       }
+      implementation("commons-io:commons-io:2.14.0") {
+        because("CVE-2024-47554 - transitive from swagger-parser")
+      }
+    }
+  }
+
+  configurations.all {
+    resolutionStrategy {
+      dependencySubstitution {
+        substitute(module("org.lz4:lz4-java")).using(module("at.yawk.lz4:lz4-java:1.8.1"))
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add a dependency constraint for `commons-io:commons-io:2.14.0` (CVE-2024-47554 path via swagger parser)
- add dependency substitution from `org.lz4:lz4-java` to `at.yawk.lz4:lz4-java:1.8.1` (CVE-2025-12183 path via Kafka)

## Why
These are runtime vulnerabilities in `/opt/cruise-control/.../dependant-libs` for Cruise Control images used by dre-streams-jvm.

## Notes
- intentionally no Jetty major migration in this PR
- follow-up in dre-streams-jvm will bump the CC commit reference and run the documented GitLab jobs
