### PR TITLE
[cruise-control] Dont set broker throttles if a global throttle is already set

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -94,15 +94,6 @@ public final class ExecutorConfig {
       + "moved, in bytes per second.";
 
   /**
-   * <code>skip.replication.throttle.rate.setting</code>
-   */
-  public static final String SKIP_REPLICATION_THROTTLE_RATE_SETTING_CONFIG = "skip.replication.throttle.rate.setting";
-  public static final boolean DEFAULT_SKIP_REPLICATION_THROTTLE_RATE_SETTING = false;
-  public static final String SKIP_REPLICATION_THROTTLE_RATE_SETTING_DOC = "If true, Cruise Control will set throttled "
-      + "replicas on topics during rebalances but will not set or remove throttle rates on brokers. This allows an "
-      + "external system to manage per-broker throttle rates independently.";
-
-  /**
    * <code>replica.movement.strategies</code>
    */
   public static final String REPLICA_MOVEMENT_STRATEGIES_CONFIG = "replica.movement.strategies";
@@ -557,11 +548,6 @@ public final class ExecutorConfig {
                             DEFAULT_DEFAULT_REPLICATION_THROTTLE,
                             ConfigDef.Importance.MEDIUM,
                             DEFAULT_REPLICATION_THROTTLE_DOC)
-                    .define(SKIP_REPLICATION_THROTTLE_RATE_SETTING_CONFIG,
-                            ConfigDef.Type.BOOLEAN,
-                            DEFAULT_SKIP_REPLICATION_THROTTLE_RATE_SETTING,
-                            ConfigDef.Importance.MEDIUM,
-                            SKIP_REPLICATION_THROTTLE_RATE_SETTING_DOC)
                     .define(REPLICA_MOVEMENT_STRATEGIES_CONFIG,
                             ConfigDef.Type.LIST,
                             DEFAULT_REPLICA_MOVEMENT_STRATEGIES,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1606,9 +1606,8 @@ public class Executor {
 
     private void interBrokerMoveReplicas() throws InterruptedException, ExecutionException, TimeoutException {
       Set<Integer> currentDeadBrokersWithReplicas = _loadMonitor.deadBrokersWithReplicas(MAX_METADATA_WAIT_MS);
-      boolean skipThrottleRateSetting = _config.getBoolean(ExecutorConfig.SKIP_REPLICATION_THROTTLE_RATE_SETTING_CONFIG);
       ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, _replicationThrottle,
-          skipThrottleRateSetting, currentDeadBrokersWithReplicas);
+          currentDeadBrokersWithReplicas);
       int numTotalPartitionMovements = _executionTaskManager.numRemainingInterBrokerPartitionMovements();
       long totalDataToMoveInMB = _executionTaskManager.remainingInterBrokerDataToMoveInMB();
       long startTime = System.currentTimeMillis();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -80,12 +80,17 @@ class ReplicationThrottleHelper {
   void setThrottles(List<ExecutionProposal> replicaMovementProposals)
   throws ExecutionException, InterruptedException, TimeoutException {
     if (throttlingEnabled()) {
-      LOG.info("Setting a rebalance throttle of {} bytes/sec", _throttleRate);
-      Set<Integer> participatingBrokers = getParticipatingBrokers(replicaMovementProposals);
-      Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(replicaMovementProposals);
-      for (int broker : participatingBrokers) {
-        setThrottledRateIfNecessary(broker);
+      boolean clusterWideThrottle = hasClusterWideThrottle();
+      if (clusterWideThrottle) {
+        LOG.info("Skipping broker throttle rate: a cluster-wide replication throttle is already set externally");
+      } else {
+        LOG.info("Setting a rebalance throttle of {} bytes/sec", _throttleRate);
+        Set<Integer> participatingBrokers = getParticipatingBrokers(replicaMovementProposals);
+        for (int broker : participatingBrokers) {
+          setThrottledRateIfNecessary(broker);
+        }
       }
+      Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(replicaMovementProposals);
       for (Map.Entry<String, Set<String>> entry : throttledReplicas.entrySet()) {
         setThrottledReplicas(entry.getKey(), entry.getValue());
       }
@@ -113,6 +118,7 @@ class ReplicationThrottleHelper {
   void clearThrottles(List<ExecutionTask> completedTasks, List<ExecutionTask> inProgressTasks)
   throws ExecutionException, InterruptedException, TimeoutException {
     if (throttlingEnabled()) {
+      boolean clusterWideThrottle = hasClusterWideThrottle();
       List<ExecutionProposal> completedProposals =
         completedTasks
           .stream()
@@ -121,29 +127,33 @@ class ReplicationThrottleHelper {
           .map(ExecutionTask::proposal)
           .collect(Collectors.toList());
 
-      // These are the brokers which have completed a task with
-      // inter-broker replica movement
-      Set<Integer> participatingBrokers = getParticipatingBrokers(completedProposals);
+      if (clusterWideThrottle) {
+        LOG.info("Skipping broker throttle rate removal: a cluster-wide replication throttle is already set externally");
+      } else {
+        // These are the brokers which have completed a task with
+        // inter-broker replica movement
+        Set<Integer> participatingBrokers = getParticipatingBrokers(completedProposals);
 
-      List<ExecutionProposal> inProgressProposals =
-        inProgressTasks
-          .stream()
-          .filter(this::taskIsInProgress)
-          .map(ExecutionTask::proposal)
-          .collect(Collectors.toList());
+        List<ExecutionProposal> inProgressProposals =
+          inProgressTasks
+            .stream()
+            .filter(this::taskIsInProgress)
+            .map(ExecutionTask::proposal)
+            .collect(Collectors.toList());
 
-      // These are the brokers which currently have in-progress
-      // inter-broker replica movement
-      Set<Integer> brokersWithInProgressTasks = getParticipatingBrokers(inProgressProposals);
+        // These are the brokers which currently have in-progress
+        // inter-broker replica movement
+        Set<Integer> brokersWithInProgressTasks = getParticipatingBrokers(inProgressProposals);
 
-      // Remove the brokers with in-progress replica moves from the brokers that have
-      // completed inter-broker replica moves
-      Set<Integer> brokersToRemoveThrottlesFrom = new TreeSet<>(participatingBrokers);
-      brokersToRemoveThrottlesFrom.removeAll(brokersWithInProgressTasks);
+        // Remove the brokers with in-progress replica moves from the brokers that have
+        // completed inter-broker replica moves
+        Set<Integer> brokersToRemoveThrottlesFrom = new TreeSet<>(participatingBrokers);
+        brokersToRemoveThrottlesFrom.removeAll(brokersWithInProgressTasks);
 
-      LOG.info("Removing replica movement throttles from brokers in the cluster: {}", brokersToRemoveThrottlesFrom);
-      for (int broker : brokersToRemoveThrottlesFrom) {
-        removeThrottledRateFromBroker(broker);
+        LOG.info("Removing replica movement throttles from brokers in the cluster: {}", brokersToRemoveThrottlesFrom);
+        for (int broker : brokersToRemoveThrottlesFrom) {
+          removeThrottledRateFromBroker(broker);
+        }
       }
 
       Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(completedProposals);
@@ -155,6 +165,23 @@ class ReplicationThrottleHelper {
 
   private boolean throttlingEnabled() {
     return _throttleRate != null;
+  }
+
+  private boolean hasClusterWideThrottle() throws ExecutionException, InterruptedException, TimeoutException {
+    ConfigResource defaultBrokerResource = new ConfigResource(ConfigResource.Type.BROKER, "");
+    Config defaultBrokerConfigs = getEntityConfigs(defaultBrokerResource);
+    if (defaultBrokerConfigs == null) {
+      return false;
+    }
+    for (String throttleKey : Arrays.asList(LEADER_REPLICATION_THROTTLED_RATE_CONFIG, FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG)) {
+      ConfigEntry entry = defaultBrokerConfigs.get(throttleKey);
+      if (entry == null
+          || (!entry.source().equals(ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)
+              && !entry.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private Set<Integer> getParticipatingBrokers(List<ExecutionProposal> replicaMovementProposals) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -48,31 +48,30 @@ class ReplicationThrottleHelper {
   private static final int DEFAULT_RETRY_BACKOFF_BASE = 2;
   private final AdminClient _adminClient;
   private final Long _throttleRate;
-  private final boolean _skipThrottleRateSetting;
   private final int _retries;
   private long _maxDelayMs;
   private final Set<Integer> _deadBrokers;
 
-  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, boolean skipThrottleRateSetting) {
-    this(adminClient, throttleRate, skipThrottleRateSetting, RETRIES, MAX_DELAY_MS, new HashSet<>());
+  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate) {
+    this(adminClient, throttleRate, RETRIES, MAX_DELAY_MS);
   }
 
-  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, boolean skipThrottleRateSetting,
-                             Set<Integer> deadBrokers) {
-    this(adminClient, throttleRate, skipThrottleRateSetting, RETRIES, MAX_DELAY_MS, deadBrokers);
+  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, Set<Integer> deadBrokers) {
+    this(adminClient, throttleRate, RETRIES, MAX_DELAY_MS, deadBrokers);
   }
 
   // for testing
-  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, boolean skipThrottleRateSetting,
-                             int retries, long maxDelayMs) {
-    this(adminClient, throttleRate, skipThrottleRateSetting, retries, maxDelayMs, new HashSet<>());
-  }
-
-  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, boolean skipThrottleRateSetting,
-                             int retries, long maxDelayMs, Set<Integer> deadBrokers) {
+  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, int retries, long maxDelayMs) {
     this._adminClient = adminClient;
     this._throttleRate = throttleRate;
-    this._skipThrottleRateSetting = skipThrottleRateSetting;
+    this._retries = retries;
+    this._maxDelayMs = maxDelayMs;
+    this._deadBrokers = new HashSet<Integer>();
+  }
+
+  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate, int retries, long maxDelayMs, Set<Integer> deadBrokers) {
+    this._adminClient = adminClient;
+    this._throttleRate = throttleRate;
     this._retries = retries;
     this._maxDelayMs = maxDelayMs;
     this._deadBrokers = deadBrokers;
@@ -80,16 +79,12 @@ class ReplicationThrottleHelper {
 
   void setThrottles(List<ExecutionProposal> replicaMovementProposals)
   throws ExecutionException, InterruptedException, TimeoutException {
-    if (throttlingEnabled() || _skipThrottleRateSetting) {
+    if (throttlingEnabled()) {
+      LOG.info("Setting a rebalance throttle of {} bytes/sec", _throttleRate);
+      Set<Integer> participatingBrokers = getParticipatingBrokers(replicaMovementProposals);
       Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(replicaMovementProposals);
-      if (throttlingEnabled() && !_skipThrottleRateSetting) {
-        LOG.info("Setting a rebalance throttle of {} bytes/sec", _throttleRate);
-        Set<Integer> participatingBrokers = getParticipatingBrokers(replicaMovementProposals);
-        for (int broker : participatingBrokers) {
-          setThrottledRateIfNecessary(broker);
-        }
-      } else {
-        LOG.info("Skipping throttle rate setting; throttled replicas will still be set");
+      for (int broker : participatingBrokers) {
+        setThrottledRateIfNecessary(broker);
       }
       for (Map.Entry<String, Set<String>> entry : throttledReplicas.entrySet()) {
         setThrottledReplicas(entry.getKey(), entry.getValue());
@@ -117,7 +112,7 @@ class ReplicationThrottleHelper {
   // clear throttles for a specific list of execution tasks
   void clearThrottles(List<ExecutionTask> completedTasks, List<ExecutionTask> inProgressTasks)
   throws ExecutionException, InterruptedException, TimeoutException {
-    if (throttlingEnabled() || _skipThrottleRateSetting) {
+    if (throttlingEnabled()) {
       List<ExecutionProposal> completedProposals =
         completedTasks
           .stream()
@@ -126,31 +121,29 @@ class ReplicationThrottleHelper {
           .map(ExecutionTask::proposal)
           .collect(Collectors.toList());
 
-      if (throttlingEnabled() && !_skipThrottleRateSetting) {
-        // These are the brokers which have completed a task with
-        // inter-broker replica movement
-        Set<Integer> participatingBrokers = getParticipatingBrokers(completedProposals);
+      // These are the brokers which have completed a task with
+      // inter-broker replica movement
+      Set<Integer> participatingBrokers = getParticipatingBrokers(completedProposals);
 
-        List<ExecutionProposal> inProgressProposals =
-          inProgressTasks
-            .stream()
-            .filter(this::taskIsInProgress)
-            .map(ExecutionTask::proposal)
-            .collect(Collectors.toList());
+      List<ExecutionProposal> inProgressProposals =
+        inProgressTasks
+          .stream()
+          .filter(this::taskIsInProgress)
+          .map(ExecutionTask::proposal)
+          .collect(Collectors.toList());
 
-        // These are the brokers which currently have in-progress
-        // inter-broker replica movement
-        Set<Integer> brokersWithInProgressTasks = getParticipatingBrokers(inProgressProposals);
+      // These are the brokers which currently have in-progress
+      // inter-broker replica movement
+      Set<Integer> brokersWithInProgressTasks = getParticipatingBrokers(inProgressProposals);
 
-        // Remove the brokers with in-progress replica moves from the brokers that have
-        // completed inter-broker replica moves
-        Set<Integer> brokersToRemoveThrottlesFrom = new TreeSet<>(participatingBrokers);
-        brokersToRemoveThrottlesFrom.removeAll(brokersWithInProgressTasks);
+      // Remove the brokers with in-progress replica moves from the brokers that have
+      // completed inter-broker replica moves
+      Set<Integer> brokersToRemoveThrottlesFrom = new TreeSet<>(participatingBrokers);
+      brokersToRemoveThrottlesFrom.removeAll(brokersWithInProgressTasks);
 
-        LOG.info("Removing replica movement throttles from brokers in the cluster: {}", brokersToRemoveThrottlesFrom);
-        for (int broker : brokersToRemoveThrottlesFrom) {
-          removeThrottledRateFromBroker(broker);
-        }
+      LOG.info("Removing replica movement throttles from brokers in the cluster: {}", brokersToRemoveThrottlesFrom);
+      for (int broker : brokersToRemoveThrottlesFrom) {
+        removeThrottledRateFromBroker(broker);
       }
 
       Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(completedProposals);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailureDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailureDetectorTest.java
@@ -131,12 +131,11 @@ public class BrokerFailureDetectorTest extends CCKafkaIntegrationTestHarness {
       int brokerId = 0;
       long anomalyTime = mockTime.milliseconds();
       killBroker(brokerId);
-      // Start detection.
+      // Poll until the detector sees the failed broker or timeout.
       long start = System.currentTimeMillis();
       while (detector.failedBrokers().isEmpty() && System.currentTimeMillis() < start + 15000) {
-        // wait for the anomalies to be drained.
+        detector.run();
       }
-      detector.run();
       assertEquals(Collections.singletonMap(brokerId, 100L), detector.failedBrokers());
       failedBrokerListString = detector.loadPersistedFailedBrokerList();
       assertEquals(String.format("%d=%d", brokerId, anomalyTime), failedBrokerListString);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -111,6 +111,68 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   }
 
   @Test
+  public void testSkipsBrokerThrottleRateWhenClusterWideThrottleExists() throws Exception {
+    createTopics();
+
+    final long clusterWideRate = 50000000L;
+    final long throttleRate = 100L;
+
+    // Set a cluster-wide throttle via the default broker entity (equivalent to kafka-configs --entity-default)
+    ConfigResource defaultBrokerCf = new ConfigResource(ConfigResource.Type.BROKER, "");
+    _adminClient.incrementalAlterConfigs(Collections.singletonMap(defaultBrokerCf, Arrays.asList(
+        new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG,
+            String.valueOf(clusterWideRate)), AlterConfigOp.OpType.SET),
+        new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG,
+            String.valueOf(clusterWideRate)), AlterConfigOp.OpType.SET)
+    ))).all().get();
+
+    // Wait for the cluster-wide config to be visible before proceeding
+    long deadline = System.currentTimeMillis() + 30000;
+    while (System.currentTimeMillis() < deadline) {
+      Config cfg = _adminClient.describeConfigs(Collections.singletonList(defaultBrokerCf)).all().get().get(defaultBrokerCf);
+      ConfigEntry entry = cfg == null ? null : cfg.get(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG);
+      if (entry != null && entry.source().equals(ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)) {
+        break;
+      }
+      Thread.sleep(200);
+    }
+
+    try {
+      ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
+      ExecutionProposal proposal = new ExecutionProposal(new TopicPartition(TOPIC0, 0), 100,
+          new ReplicaPlacementInfo(0),
+          Arrays.asList(new ReplicaPlacementInfo(0), new ReplicaPlacementInfo(1)),
+          Arrays.asList(new ReplicaPlacementInfo(0), new ReplicaPlacementInfo(2)));
+      ExecutionTask task = completedTaskForProposal(0, proposal);
+
+      throttleHelper.setThrottles(Collections.singletonList(proposal));
+
+      // Per-broker dynamic throttle rates should NOT have been set by CC
+      for (int i = 0; i < clusterSize(); i++) {
+        ConfigResource brokerCf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(i));
+        Config brokerConfig = _adminClient.describeConfigs(Collections.singletonList(brokerCf)).all().get().get(brokerCf);
+        ConfigEntry leaderEntry = brokerConfig.get(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG);
+        assertFalse("CC should not have set a per-broker throttle rate when a cluster-wide throttle exists",
+            leaderEntry != null && leaderEntry.source().equals(ConfigEntry.ConfigSource.DYNAMIC_BROKER_CONFIG));
+      }
+      // Topic-level throttled replicas should still be set
+      assertExpectedThrottledReplicas(TOPIC0, "0:0,0:1,0:2");
+
+      throttleHelper.clearThrottles(Collections.singletonList(task), Collections.emptyList());
+
+      // Topic-level throttled replicas should be cleared
+      assertExpectedThrottledReplicas(TOPIC0, "");
+    } finally {
+      _adminClient.incrementalAlterConfigs(Collections.singletonMap(defaultBrokerCf, Arrays.asList(
+          new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, null),
+              AlterConfigOp.OpType.DELETE),
+          new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, null),
+              AlterConfigOp.OpType.DELETE)
+      ))).all().get();
+    }
+  }
+
+  @Test
   public void testIsNoOpWhenThrottleIsNull() throws Exception {
     AdminClient mockAdminClient = EasyMock.strictMock(AdminClient.class);
     EasyMock.replay(mockAdminClient);
@@ -165,6 +227,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
                     ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG))
     );
     // Expect that only the dynamic throttle rate configs are removed when clearing throttles
+    expectDescribeDefaultBrokerConfigs(mockAdminClient, EMPTY_CONFIG);
     expectDescribeBrokerConfigs(mockAdminClient, brokers, brokerConfig);
     expectIncrementalBrokerConfigs(mockAdminClient, brokers);
     expectDescribeBrokerConfigs(mockAdminClient, brokers, brokerConfig2);
@@ -178,6 +241,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     // Case 2: a situation where Topic0 gets deleted after its configs were read.
     EasyMock.reset(mockAdminClient);
+    expectDescribeDefaultBrokerConfigs(mockAdminClient, EMPTY_CONFIG);
     expectDescribeBrokerConfigs(mockAdminClient, brokers);
     expectIncrementalBrokerConfigs(mockAdminClient, brokers);
     expectDescribeBrokerConfigs(mockAdminClient, brokers, EMPTY_CONFIG);
@@ -215,6 +279,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate);
 
     // Case 1: a situation where Topic0 does not exist. Hence no property is returned upon read.
+    expectDescribeDefaultBrokerConfigs(mockAdminClient, EMPTY_CONFIG);
     expectDescribeBrokerConfigs(mockAdminClient, brokers);
     expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
     expectListTopics(mockAdminClient, Collections.emptySet());
@@ -227,6 +292,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     // Case 2: a situation where Topic0 gets deleted after its configs were read. Change configs should not fail.
     EasyMock.reset(mockAdminClient);
+    expectDescribeDefaultBrokerConfigs(mockAdminClient, EMPTY_CONFIG);
     expectDescribeBrokerConfigs(mockAdminClient, brokers);
     String throttledReplicas = brokerId0 + "," + brokerId1;
     Config topicConfigs = new Config(Arrays.asList(
@@ -602,6 +668,18 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(topics);
     EasyMock.expect(adminClient.listTopics()).andReturn(mockListTopicsResult);
     EasyMock.replay(mockListTopicsResult, mockFuture);
+  }
+
+  private void expectDescribeDefaultBrokerConfigs(AdminClient adminClient, Config defaultConfig)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, "");
+    Map<ConfigResource, Config> configs = Collections.singletonMap(cf, defaultConfig);
+    DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
+    KafkaFuture<Map<ConfigResource, Config>> mockFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(configs);
+    EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture);
+    EasyMock.expect(adminClient.describeConfigs(Collections.singletonList(cf))).andReturn(mockDescribeConfigsResult);
+    EasyMock.replay(mockDescribeConfigsResult, mockFuture);
   }
 
   private void expectDescribeBrokerConfigs(AdminClient adminClient, List<Integer> brokers)

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -116,7 +116,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.replay(mockAdminClient);
 
     // Test would fail on any unexpected interactions with the adminClient
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, null, false);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, null);
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition("topic", 0),
                                            100,
                                                        new ReplicaPlacementInfo(0),
@@ -146,7 +146,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
                                                        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId2)));
 
     AdminClient mockAdminClient = EasyMock.mock(AdminClient.class);
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate, false);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate);
 
     // Case 1: a situation where Topic0 does not exist. Hence no property is returned upon read.
 
@@ -212,7 +212,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
                                                        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId2)));
 
     AdminClient mockAdminClient = EasyMock.strictMock(AdminClient.class);
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate, false);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate);
 
     // Case 1: a situation where Topic0 does not exist. Hence no property is returned upon read.
     expectDescribeBrokerConfigs(mockAdminClient, brokers);
@@ -246,7 +246,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     createTopics();
 
     final long throttleRate = 100L;
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate, false);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition(TOPIC0, 0),
                                            100,
                                                        new ReplicaPlacementInfo(0),
@@ -278,7 +278,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     createTopics();
 
     final long throttleRate = 100L;
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate, false);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
     ExecutionProposal proposal = new ExecutionProposal(
         new TopicPartition(TOPIC0, 0),
         100,
@@ -352,7 +352,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     final long throttleRate = 100L;
 
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate, false);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
 
     // Set replica throttle config values for both topics
     setWildcardThrottleReplicaForTopic(throttleHelper, TOPIC0);
@@ -423,7 +423,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     final long throttleRate = 100L;
 
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate, false);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition(TOPIC0, 0),
                                            100,
                                                        new ReplicaPlacementInfo(0),
@@ -497,7 +497,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
       expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, true);
     }
     EasyMock.replay(mockAdminClient);
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, 100L, false, retries, maxDelayMs);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, 100L, maxDelayMs, retries);
     ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, TOPIC0);
     assertThrows(IllegalStateException.class, () -> throttleHelper.waitForConfigs(cf, Collections.singletonList(
             new AlterConfigOp(new ConfigEntry("k", "v"), AlterConfigOp.OpType.SET)


### PR DESCRIPTION
## Summary
As I was rolling out https://github.com/DataDog/cruise-control/pull/42 I decided that the solution of statically disabling cruise control throttling might not be a good idea. If we ever turn off our external throttle setter than cruise control will still not set throttles and we could cause traffic spikes on rebalancing brokers.

This PR is an alternative solution, where instead of a static config that decides whether throttles are set, we check if there is a global throttle already set. If there is one, then we skip setting throttles completely.

If we disable our external global throttle, cruise control will start setting its own throttles again. This also alleviates the need to set a property on all cruise control instances.
