### PR TITLE
feat(executor): limit inter-broker data per source broker

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -86,6 +86,16 @@ public final class ExecutorConfig {
       + "max.num.cluster.partition.movements throttles the maximum partition movements across the cluster";
 
   /**
+   * <code>max.inter.broker.partition.movement.data.per.source.broker.mb</code>
+   */
+  public static final String MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB_CONFIG =
+      "max.inter.broker.partition.movement.data.per.source.broker.mb";
+  public static final long DEFAULT_MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB = 0L;
+  public static final String MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB_DOC = "The maximum amount "
+      + "of data in MB selected from the same source broker for inter-broker partition movement tasks in a single executor "
+      + "batch. Set to 0 to disable this limit.";
+
+  /**
    * <code>default.replication.throttle</code>
    */
   public static final String DEFAULT_REPLICATION_THROTTLE_CONFIG = "default.replication.throttle";
@@ -543,6 +553,12 @@ public final class ExecutorConfig {
                             atLeast(1),
                             ConfigDef.Importance.MEDIUM,
                             MAX_NUM_CLUSTER_PARTITION_MOVEMENTS_DOC)
+                    .define(MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB_CONFIG,
+                            ConfigDef.Type.LONG,
+                            DEFAULT_MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB,
+                            atLeast(0),
+                            ConfigDef.Importance.MEDIUM,
+                            MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB_DOC)
                     .define(DEFAULT_REPLICATION_THROTTLE_CONFIG,
                             ConfigDef.Type.LONG,
                             DEFAULT_DEFAULT_REPLICATION_THROTTLE,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -7,6 +7,7 @@ package com.linkedin.kafka.cruisecontrol.executor;
 import com.linkedin.cruisecontrol.common.utils.Utils;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.executor.concurrency.ExecutionConcurrencyManager;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.BaseReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy;
@@ -80,6 +81,7 @@ public class ExecutionTaskPlanner {
   private final long _taskExecutionAlertingThresholdMs;
   private final double _interBrokerReplicaMovementRateAlertingThreshold;
   private final double _intraBrokerReplicaMovementRateAlertingThreshold;
+  private final long _maxInterBrokerPartitionMovementDataPerSourceBrokerMB;
   private static final int PRIORITIZE_BROKER_1 = -1;
   private static final int PRIORITIZE_BROKER_2 = 1;
   private static final int PRIORITIZE_NONE = 0;
@@ -100,6 +102,8 @@ public class ExecutionTaskPlanner {
     _taskExecutionAlertingThresholdMs = config.getLong(TASK_EXECUTION_ALERTING_THRESHOLD_MS_CONFIG);
     _interBrokerReplicaMovementRateAlertingThreshold = config.getDouble(INTER_BROKER_REPLICA_MOVEMENT_RATE_ALERTING_THRESHOLD_CONFIG);
     _intraBrokerReplicaMovementRateAlertingThreshold = config.getDouble(INTRA_BROKER_REPLICA_MOVEMENT_RATE_ALERTING_THRESHOLD_CONFIG);
+    _maxInterBrokerPartitionMovementDataPerSourceBrokerMB =
+        config.getLong(ExecutorConfig.MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB_CONFIG);
     _adminClient = adminClient;
     List<String> defaultReplicaMovementStrategies = config.getList(DEFAULT_REPLICA_MOVEMENT_STRATEGIES_CONFIG);
     if (defaultReplicaMovementStrategies == null || defaultReplicaMovementStrategies.isEmpty()) {
@@ -362,6 +366,7 @@ public class ExecutionTaskPlanner {
     interPartMoveBrokerIds.addAll(_interPartMoveTasksByBrokerId.keySet());
     Set<Integer> brokerInvolved = new HashSet<>();
     Set<TopicPartition> partitionsInvolved = new HashSet<>();
+    Map<Integer, Long> selectedDataBySourceBroker = new HashMap<>();
 
     int numInProgressPartitions = inProgressPartitions.size();
     boolean maxPartitionMovesReached = false;
@@ -407,8 +412,12 @@ public class ExecutionTaskPlanner {
           if (isExecutableProposal(task.proposal(), readyBrokers)
               && !inProgressPartitions.contains(tp)
               && !partitionsInvolved.contains(tp)) {
+            if (!withinInterBrokerPartitionMovementDataBudget(task.proposal(), sourceBroker, selectedDataBySourceBroker)) {
+              continue;
+            }
             partitionsInvolved.add(tp);
             executableReplicaMovements.add(task);
+            selectedDataBySourceBroker.merge(sourceBroker, task.proposal().dataToMoveInMB(), Long::sum);
             // Record the brokers as involved in this round and stop involving them again in this round.
             brokerInvolved.add(sourceBroker);
             brokerInvolved.addAll(destinationBrokers);
@@ -436,6 +445,19 @@ public class ExecutionTaskPlanner {
       }
     }
     return executableReplicaMovements;
+  }
+
+  private boolean withinInterBrokerPartitionMovementDataBudget(ExecutionProposal proposal,
+                                                               int sourceBroker,
+                                                               Map<Integer, Long> selectedDataBySourceBroker) {
+    if (_maxInterBrokerPartitionMovementDataPerSourceBrokerMB <= 0 || !selectedDataBySourceBroker.containsKey(sourceBroker)) {
+      return true;
+    }
+    if (proposal.dataToMoveInMB() == 0) {
+      return true;
+    }
+    return selectedDataBySourceBroker.get(sourceBroker) + proposal.dataToMoveInMB()
+           <= _maxInterBrokerPartitionMovementDataPerSourceBrokerMB;
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
@@ -362,6 +362,96 @@ public class ExecutionTaskPlannerTest {
   }
 
   @Test
+  public void testInterBrokerPartitionMovementDataBudgetPerSourceBroker() {
+    ExecutionProposal source0Small =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 10), 10, _r0, List.of(_r0, _r2), List.of(_r2, _r3));
+    ExecutionProposal source0Medium =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 11), 20, _r0, List.of(_r0, _r4), List.of(_r4, _r5));
+    ExecutionProposal source1Medium =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 12), 20, _r1, List.of(_r1, _r2), List.of(_r2, _r4));
+    List<ExecutionProposal> proposals = List.of(source0Small, source0Medium, source1Medium);
+
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    props.setProperty(ExecutorConfig.MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB_CONFIG, "25");
+    props.setProperty(ExecutorConfig.DEFAULT_REPLICA_MOVEMENT_STRATEGIES_CONFIG, BaseReplicaMovementStrategy.class.getName());
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, new KafkaCruiseControlConfig(props));
+    planner.addExecutionProposals(proposals, strategyOptionsForProposals(proposals), null);
+
+    List<ExecutionTask> firstBatch = planner.getInterBrokerReplicaMovementTasks(readyBrokers(6, 10), Collections.emptySet(),
+                                                                                _defaultPartitionsMaxCap);
+    assertEquals(Set.of(source0Small, source1Medium), proposalsForTasks(firstBatch));
+
+    List<ExecutionTask> secondBatch = planner.getInterBrokerReplicaMovementTasks(readyBrokers(6, 10), Collections.emptySet(),
+                                                                                 _defaultPartitionsMaxCap);
+    assertEquals(Collections.singleton(source0Medium), proposalsForTasks(secondBatch));
+  }
+
+  @Test
+  public void testInterBrokerPartitionMovementDataBudgetAllowsFirstOversizedTask() {
+    ExecutionProposal oversized =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 20), 30, _r0, List.of(_r0, _r2), List.of(_r2, _r3));
+    ExecutionProposal followUp =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 21), 10, _r0, List.of(_r0, _r4), List.of(_r4, _r5));
+    List<ExecutionProposal> proposals = List.of(oversized, followUp);
+
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    props.setProperty(ExecutorConfig.MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB_CONFIG, "25");
+    props.setProperty(ExecutorConfig.DEFAULT_REPLICA_MOVEMENT_STRATEGIES_CONFIG, BaseReplicaMovementStrategy.class.getName());
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, new KafkaCruiseControlConfig(props));
+    planner.addExecutionProposals(proposals, strategyOptionsForProposals(proposals), null);
+
+    List<ExecutionTask> firstBatch = planner.getInterBrokerReplicaMovementTasks(readyBrokers(6, 10), Collections.emptySet(),
+                                                                                _defaultPartitionsMaxCap);
+    assertEquals(Collections.singleton(oversized), proposalsForTasks(firstBatch));
+
+    List<ExecutionTask> secondBatch = planner.getInterBrokerReplicaMovementTasks(readyBrokers(6, 10), Collections.emptySet(),
+                                                                                 _defaultPartitionsMaxCap);
+    assertEquals(Collections.singleton(followUp), proposalsForTasks(secondBatch));
+  }
+
+  @Test
+  public void testInterBrokerPartitionMovementDataBudgetAllowsZeroDataTasksAfterOversizedTask() {
+    ExecutionProposal oversized =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 25), 30, _r0, List.of(_r0, _r2), List.of(_r2, _r3));
+    ExecutionProposal zeroDataReorder =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 26), 30, _r0, List.of(_r0, _r2), List.of(_r2, _r0));
+    ExecutionProposal followUp =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 27), 10, _r0, List.of(_r0, _r4), List.of(_r4, _r5));
+    List<ExecutionProposal> proposals = List.of(oversized, zeroDataReorder, followUp);
+
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    props.setProperty(ExecutorConfig.MAX_INTER_BROKER_PARTITION_MOVEMENT_DATA_PER_SOURCE_BROKER_MB_CONFIG, "25");
+    props.setProperty(ExecutorConfig.DEFAULT_REPLICA_MOVEMENT_STRATEGIES_CONFIG, BaseReplicaMovementStrategy.class.getName());
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, new KafkaCruiseControlConfig(props));
+    planner.addExecutionProposals(proposals, strategyOptionsForProposals(proposals), null);
+
+    List<ExecutionTask> firstBatch = planner.getInterBrokerReplicaMovementTasks(readyBrokers(6, 10), Collections.emptySet(),
+                                                                                _defaultPartitionsMaxCap);
+    assertEquals(Set.of(oversized, zeroDataReorder), proposalsForTasks(firstBatch));
+
+    List<ExecutionTask> secondBatch = planner.getInterBrokerReplicaMovementTasks(readyBrokers(6, 10), Collections.emptySet(),
+                                                                                 _defaultPartitionsMaxCap);
+    assertEquals(Collections.singleton(followUp), proposalsForTasks(secondBatch));
+  }
+
+  @Test
+  public void testInterBrokerPartitionMovementDataBudgetDisabledByDefault() {
+    ExecutionProposal source0Small =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 30), 10, _r0, List.of(_r0, _r2), List.of(_r2, _r3));
+    ExecutionProposal source0Medium =
+        new ExecutionProposal(new TopicPartition(TOPIC3, 31), 20, _r0, List.of(_r0, _r4), List.of(_r4, _r5));
+    List<ExecutionProposal> proposals = List.of(source0Small, source0Medium);
+
+    ExecutionTaskPlanner planner =
+        new ExecutionTaskPlanner(null, new KafkaCruiseControlConfig(KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties()));
+    planner.addExecutionProposals(proposals, strategyOptionsForProposals(proposals), null);
+
+    List<ExecutionTask> firstBatch = planner.getInterBrokerReplicaMovementTasks(readyBrokers(6, 10), Collections.emptySet(),
+                                                                                _defaultPartitionsMaxCap);
+    assertEquals(Set.of(source0Small, source0Medium), proposalsForTasks(firstBatch));
+  }
+
+  @Test
   public void testDynamicConfigReplicaMovementStrategy() {
     List<ExecutionProposal> proposals = new ArrayList<>();
     proposals.add(_partitionMovement0);
@@ -537,5 +627,26 @@ public class ExecutionTaskPlannerTest {
     return new PartitionInfo(proposal.topicPartition().topic(),
                              proposal.topicPartition().partition(), isrArray[0], isrArray,
                              isPartitionURP ? Arrays.copyOf(isrArray, 1) : isrArray);
+  }
+
+  private StrategyOptions strategyOptionsForProposals(List<ExecutionProposal> proposals) {
+    Set<PartitionInfo> partitions = new HashSet<>();
+    proposals.forEach(proposal -> partitions.add(generatePartitionInfo(proposal, false)));
+    Cluster expectedCluster = new Cluster(null, _rf4ExpectedNodes, partitions, Collections.emptySet(), Collections.emptySet());
+    return new StrategyOptions.Builder(expectedCluster).build();
+  }
+
+  private Map<Integer, Integer> readyBrokers(int numBrokers, int brokerConcurrency) {
+    Map<Integer, Integer> readyBrokers = new HashMap<>();
+    for (int brokerId = 0; brokerId < numBrokers; brokerId++) {
+      readyBrokers.put(brokerId, brokerConcurrency);
+    }
+    return readyBrokers;
+  }
+
+  private Set<ExecutionProposal> proposalsForTasks(List<ExecutionTask> tasks) {
+    Set<ExecutionProposal> proposals = new HashSet<>();
+    tasks.forEach(task -> proposals.add(task.proposal()));
+    return proposals;
   }
 }


### PR DESCRIPTION
## Summary
1. Why: Cruise Control currently limits inter-broker partition movement count, but not the amount of data selected from any individual source broker in a planning batch.
2. What: Add `max.inter.broker.partition.movement.data.per.source.broker.mb` to cap selected inter-broker movement data per source broker, while keeping the default disabled, allowing the first selected task for a source broker even if it exceeds the configured budget, and allowing zero-data inter-broker reorder tasks to run without consuming or being blocked by the data budget.

## Expected Behavior
When the new config is set to a positive value, `ExecutionTaskPlanner` avoids selecting additional data-moving inter-broker replica movement tasks from a source broker once the selected movement data for that source would exceed the configured budget. When the config is unset or `0`, planning behavior remains unchanged. Zero-data inter-broker reorder tasks can still be selected alongside budget-limited tasks because they do not add source-broker movement data.

## Actual Behavior
Before this change, the planner could select multiple large inter-broker movements from the same source broker in a single batch as long as movement-count constraints allowed it.

## Steps to Reproduce
1. Configure multiple inter-broker replica movements with the same source broker.
2. Set `max.inter.broker.partition.movement.data.per.source.broker.mb` to a positive value.
3. Ask `ExecutionTaskPlanner` for ready inter-broker replica movement tasks.

## Known Workarounds
Operators can manually shepherd an overloaded reassignment:

1. Identify the hot partitions and the source broker serving the new replicas.
2. Apply low follower replication throttles to selected brokers for the current reassignment.
3. Raise throttles on the followers that should catch up first.
4. Trigger preferred leader election when needed to move traffic off the overloaded source broker.
5. Wait for the hottest partition moves to complete before allowing more replicas to catch up.

This is effective as an emergency mitigation, but it is manual, reactive, and requires per-cluster intervention after Cruise Control has already selected a risky batch of movements.

## Additional evidence
1. Environment: local macOS workspace with SDKMAN Java `17.0.18-zulu`.
2. Targeted test:

```text
JAVA_HOME="$HOME/.sdkman/candidates/java/17.0.18-zulu" JAVA_TOOL_OPTIONS='-Djava.io.tmpdir=/tmp' ./gradlew :cruise-control:test --tests com.linkedin.kafka.cruisecontrol.executor.ExecutionTaskPlannerTest
BUILD SUCCESSFUL in 27s
```

3. Full build:

```text
JAVA_HOME="$HOME/.sdkman/candidates/java/17.0.18-zulu" JAVA_TOOL_OPTIONS='-Djava.io.tmpdir=/tmp' ./gradlew build
BUILD SUCCESSFUL in 8m 57s
```

## Categorization
- [ ] documentation
- [ ] bugfix
- [x] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other
